### PR TITLE
Change geoipAPI for version with free ssl to

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,2 +1,1 @@
 CLIMATE_API=http://climateapi.scottpinkelman.com/api/v1/location/
-GEOIP_API=http://ip-api.com/json

--- a/.env.production.local
+++ b/.env.production.local
@@ -1,2 +1,1 @@
 CLIMATE_API=https://plantnow.netlify.app/api/climate/
-GEOIP_API=https://plantnow.netlify.app/api/geoip/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Live now at: https://plantnow.netlify.app/
 
 ### GEOip lookup
 
-Using free: http://ip-api.com/json
+Using free: https://freegeoip.app/json/
 
 ### Climate API
 

--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,2 @@
-/api/geoip/ http://ip-api.com/json 200
 /api/climate/* http://climateapi.scottpinkelman.com/api/v1/location/:splat 200
 

--- a/datasources/GeoIpAPI.js
+++ b/datasources/GeoIpAPI.js
@@ -3,15 +3,15 @@ const { RESTDataSource } = require("apollo-datasource-rest");
 class GeoIpAPI extends RESTDataSource {
   constructor() {
     super();
-    this.baseURL = process.env.GEOIP_API;
+    this.baseURL = "https://freegeoip.app/json/";
   }
 
   async getGeoIP() {
     const data = await this.get("/").catch((e) => console.log(e));
     if (!data.status === "success") {
-      throw new Error("No geoip.."); //TODO do something more sensible
+      throw new Error("No geoip.."); //TODO Handle errors
     }
-    return { lat: data.lat, long: data.lon };
+    return { lat: data.latitude, long: data.longitude };
   }
 }
 


### PR DESCRIPTION
Using netlify redirects to bypass http -> https security issue meant the IP request came from a netlify server, and the geolocation aspect of the site was off.

This new api supports free ssl and using it instead means we can correctly identify the client geolocation to pass to the climatezone api.